### PR TITLE
ユニークの固有ドロップ復活とスコア送信機能無効化と自動ダンプ出力

### DIFF
--- a/lib/pref/pref-opt.prf
+++ b/lib/pref/pref-opt.prf
@@ -76,7 +76,7 @@ X:always_small_levels
 X:empty_levels
 Y:bound_walls_perm
 Y:last_words
-X:send_score
+#X:send_score
 X:allow_debug_opts
 
 ##### Disturbance #####

--- a/src/files.c
+++ b/src/files.c
@@ -5046,6 +5046,53 @@ errr file_character(cptr name)
 	return (0);
 }
 
+/*!
+ * @brief プレイヤーステータスをmorgue.txtにファイルダンプ出力する
+ * Hack -- Dump a character description to mogue.txt
+ * @return エラーコード
+ * @details
+ * XXX XXX XXX Allow the "full" flag to dump additional info,
+ * and trigger its usage from various places in the code.
+ */
+errr auto_file_character()
+{
+	FILE		*fff = NULL;
+	char		buf[1024];
+
+	/* Build the filename */
+	path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "morgue.txt");
+
+	/* File type is "TEXT" */
+	FILE_TYPE(FILE_TYPE_TEXT);
+
+	/* Open the non-existing file */
+	fff = my_fopen(buf, "w");
+
+	/* Invalid file */
+	if (!fff)
+	{
+		/* Message */
+		prt(_("キャラクタ情報のファイルへの書き出しに失敗しました！", "Character dump failed!"), 0, 0);
+
+		(void)inkey();
+
+		/* Error */
+		return (-1);
+	}
+
+	(void)make_character_dump(fff);
+
+	/* Close it */
+	my_fclose(fff);
+
+
+	/* Message */
+	msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
+	msg_print(NULL);
+
+	/* Success */
+	return (0);
+}
 
 /*!
  * @brief ファイル内容の一行をコンソールに出力する
@@ -6544,8 +6591,6 @@ static void show_info(void)
 	int             i, j, k, l;
 	object_type		*o_ptr;
 	store_type		*st_ptr;
-	/* #tang */
-	bool			dumped = FALSE;
 
 	/* Hack -- Know everything in the inven/equip */
 	for (i = 0; i < INVEN_TOTAL; i++)
@@ -6606,14 +6651,11 @@ static void show_info(void)
 		/* Default */
 		strcpy(out_val, "");
 
-		/* #tang 手動でダンプ出力していないならダンプ強制出力 */
-		if (!askfor(out_val, 60) && !dumped)
+		/* #tang ダンプ強制出力 */
+		if (!askfor(out_val, 60))
 		{
-			time_t now = time(NULL);
-			struct tm *t_ptr = localtime(&now);
-			sprintf(out_val, "%d%02d%02d-%02d%02d%02d.txt", t_ptr->tm_year + 1900, t_ptr->tm_mon, t_ptr->tm_mday, t_ptr->tm_hour, t_ptr->tm_min, t_ptr->tm_sec);
 			screen_save();
-			(void)file_character(out_val);
+			(void)auto_file_character("morgue.txt");
 			screen_load();
 			return;
 		}
@@ -6627,8 +6669,6 @@ static void show_info(void)
 
 		/* Dump a character file */
 		(void)file_character(out_val);
-		/* #tang */
-		dumped = TRUE;
 
 		/* Load screen */
 		screen_load();

--- a/src/files.c
+++ b/src/files.c
@@ -5046,6 +5046,55 @@ errr file_character(cptr name)
 	return (0);
 }
 
+/* #tang 自動ダンプ出力用 */
+/*!
+ * @brief プレイヤーステータスをmorgue.txtにファイルダンプ出力する
+ * Hack -- Dump a character description to mogue.txt
+ * @return エラーコード
+ * @details
+ * XXX XXX XXX Allow the "full" flag to dump additional info,
+ * and trigger its usage from various places in the code.
+ */
+errr auto_file_character()
+{
+	FILE		*fff = NULL;
+	char		buf[1024];
+
+	/* Build the filename */
+	path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "morgue.txt");
+
+	/* File type is "TEXT" */
+	FILE_TYPE(FILE_TYPE_TEXT);
+
+	/* Open the non-existing file */
+	fff = my_fopen(buf, "w");
+
+	/* Invalid file */
+	if (!fff)
+	{
+		/* Message */
+		prt(_("キャラクタ情報のファイルへの書き出しに失敗しました！", "Character dump failed!"), 0, 0);
+
+		(void)inkey();
+
+		/* Error */
+		return (-1);
+	}
+
+	(void)make_character_dump(fff);
+
+	/* Close it */
+	my_fclose(fff);
+
+
+	/* Message */
+	msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
+	msg_print(NULL);
+
+	/* Success */
+	return (0);
+}
+/* #tang */
 
 /*!
  * @brief ファイル内容の一行をコンソールに出力する
@@ -6544,8 +6593,6 @@ static void show_info(void)
 	int             i, j, k, l;
 	object_type		*o_ptr;
 	store_type		*st_ptr;
-	/* #tang */
-	bool			dumped = FALSE;
 
 	/* Hack -- Know everything in the inven/equip */
 	for (i = 0; i < INVEN_TOTAL; i++)
@@ -6606,14 +6653,11 @@ static void show_info(void)
 		/* Default */
 		strcpy(out_val, "");
 
-		/* #tang 手動でダンプ出力していないならダンプ強制出力 */
-		if (!askfor(out_val, 60) && !dumped)
+		/* #tang ダンプ強制出力 */
+		if (!askfor(out_val, 60))
 		{
-			time_t now = time(NULL);
-			struct tm *t_ptr = localtime(&now);
-			sprintf(out_val, "%d%02d%02d-%02d%02d%02d.txt", t_ptr->tm_year + 1900, t_ptr->tm_mon, t_ptr->tm_mday, t_ptr->tm_hour, t_ptr->tm_min, t_ptr->tm_sec);
 			screen_save();
-			(void)file_character(out_val);
+			(void)auto_file_character("morgue.txt");
 			screen_load();
 			return;
 		}
@@ -6627,8 +6671,6 @@ static void show_info(void)
 
 		/* Dump a character file */
 		(void)file_character(out_val);
-		/* #tang */
-		dumped = TRUE;
 
 		/* Load screen */
 		screen_load();

--- a/src/files.c
+++ b/src/files.c
@@ -6544,6 +6544,8 @@ static void show_info(void)
 	int             i, j, k, l;
 	object_type		*o_ptr;
 	store_type		*st_ptr;
+	/* #tang */
+	bool			dumped = FALSE;
 
 	/* Hack -- Know everything in the inven/equip */
 	for (i = 0; i < INVEN_TOTAL; i++)
@@ -6604,8 +6606,18 @@ static void show_info(void)
 		/* Default */
 		strcpy(out_val, "");
 
-		/* Ask for filename (or abort) */
-		if (!askfor(out_val, 60)) return;
+		/* #tang 手動でダンプ出力していないならダンプ強制出力 */
+		if (!askfor(out_val, 60) && !dumped)
+		{
+			time_t now = time(NULL);
+			struct tm *t_ptr = localtime(&now);
+			sprintf(out_val, "%d%02d%02d-%02d%02d%02d.txt", t_ptr->tm_year + 1900, t_ptr->tm_mon, t_ptr->tm_mday, t_ptr->tm_hour, t_ptr->tm_min, t_ptr->tm_sec);
+			screen_save();
+			(void)file_character(out_val);
+			screen_load();
+			return;
+		}
+		/* #tang */
 
 		/* Return means "show on screen" */
 		if (!out_val[0]) break;
@@ -6615,6 +6627,8 @@ static void show_info(void)
 
 		/* Dump a character file */
 		(void)file_character(out_val);
+		/* #tang */
+		dumped = TRUE;
 
 		/* Load screen */
 		screen_load();

--- a/src/files.c
+++ b/src/files.c
@@ -5046,53 +5046,6 @@ errr file_character(cptr name)
 	return (0);
 }
 
-/*!
- * @brief プレイヤーステータスをmorgue.txtにファイルダンプ出力する
- * Hack -- Dump a character description to mogue.txt
- * @return エラーコード
- * @details
- * XXX XXX XXX Allow the "full" flag to dump additional info,
- * and trigger its usage from various places in the code.
- */
-errr auto_file_character()
-{
-	FILE		*fff = NULL;
-	char		buf[1024];
-
-	/* Build the filename */
-	path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "morgue.txt");
-
-	/* File type is "TEXT" */
-	FILE_TYPE(FILE_TYPE_TEXT);
-
-	/* Open the non-existing file */
-	fff = my_fopen(buf, "w");
-
-	/* Invalid file */
-	if (!fff)
-	{
-		/* Message */
-		prt(_("キャラクタ情報のファイルへの書き出しに失敗しました！", "Character dump failed!"), 0, 0);
-
-		(void)inkey();
-
-		/* Error */
-		return (-1);
-	}
-
-	(void)make_character_dump(fff);
-
-	/* Close it */
-	my_fclose(fff);
-
-
-	/* Message */
-	msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
-	msg_print(NULL);
-
-	/* Success */
-	return (0);
-}
 
 /*!
  * @brief ファイル内容の一行をコンソールに出力する
@@ -6591,6 +6544,8 @@ static void show_info(void)
 	int             i, j, k, l;
 	object_type		*o_ptr;
 	store_type		*st_ptr;
+	/* #tang */
+	bool			dumped = FALSE;
 
 	/* Hack -- Know everything in the inven/equip */
 	for (i = 0; i < INVEN_TOTAL; i++)
@@ -6651,11 +6606,14 @@ static void show_info(void)
 		/* Default */
 		strcpy(out_val, "");
 
-		/* #tang ダンプ強制出力 */
-		if (!askfor(out_val, 60))
+		/* #tang 手動でダンプ出力していないならダンプ強制出力 */
+		if (!askfor(out_val, 60) && !dumped)
 		{
+			time_t now = time(NULL);
+			struct tm *t_ptr = localtime(&now);
+			sprintf(out_val, "%d%02d%02d-%02d%02d%02d.txt", t_ptr->tm_year + 1900, t_ptr->tm_mon, t_ptr->tm_mday, t_ptr->tm_hour, t_ptr->tm_min, t_ptr->tm_sec);
 			screen_save();
-			(void)auto_file_character("morgue.txt");
+			(void)file_character(out_val);
 			screen_load();
 			return;
 		}
@@ -6669,6 +6627,8 @@ static void show_info(void)
 
 		/* Dump a character file */
 		(void)file_character(out_val);
+		/* #tang */
+		dumped = TRUE;
 
 		/* Load screen */
 		screen_load();

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -1279,11 +1279,194 @@ void monster_death(int m_idx, bool drop_item)
 		int a_idx = 0;
 		int chance = 0;
 
-		/* #tang 特定モンスター固定ドロップ */
-		
 		switch (m_ptr->r_idx)
 		{
-		
+		case MON_OBERON:
+			if (one_in_(3))
+			{
+				a_idx = ART_JUDGE;
+				chance = 33;
+			}
+			else
+			{
+				a_idx = ART_AMBER;
+				chance = 50;
+			}
+			break;
+
+		case MON_GHB:
+			a_idx = ART_GHB;
+			chance = 100;
+			break;
+
+		case MON_STORMBRINGER:
+			a_idx = ART_STORMBRINGER;
+			chance = 100;
+			break;
+
+		case MON_ECHIZEN:
+			a_idx = ART_CRIMSON;
+			chance = 50;
+			break;
+
+		case MON_GANDALF:
+			a_idx = ART_ICANUS;
+			chance = 20;
+			break;
+
+		case MON_OROCHI:
+			a_idx = ART_KUSANAGI;
+			chance = 25;
+			break;
+
+		case MON_DWORKIN:
+			a_idx = ART_JUDGE;
+			chance = 20;
+			break;
+
+		case MON_SAURON:
+			if (one_in_(10))
+			{
+				a_idx = ART_POWER;
+				chance = 100;
+			}
+			else
+			{
+				a_idx = ART_AHO;
+				chance = 100;
+			}
+			break;
+
+		case MON_BRAND:
+			if (!one_in_(3))
+			{
+				a_idx = ART_BRAND;
+				chance = 25;
+			}
+			else
+			{
+				a_idx = ART_WEREWINDLE;
+				chance = 33;
+			}
+			break;
+
+		case MON_CORWIN:
+			if (!one_in_(3))
+			{
+				a_idx = ART_GRAYSWANDIR;
+				chance = 33;
+			}
+			else
+			{
+				a_idx = ART_CORWIN;
+				chance = 33;
+			}
+			break;
+
+		case MON_SURTUR:
+			if (!one_in_(3))
+			{
+				a_idx = ART_TWILIGHT;
+				chance = 100;
+			}
+			else
+			{
+				a_idx = ART_ORB_OF_FATE;
+				chance = 100;
+			}
+			break;
+
+		case MON_SARUMAN:
+			a_idx = ART_ELENDIL;
+			chance = 33;
+			break;
+
+		case MON_FIONA:
+			a_idx = ART_FIONA;
+			chance = 50;
+			break;
+
+		case MON_JULIAN:
+			a_idx = ART_JULIAN;
+			chance = 45;
+			break;
+
+		case MON_KLING:
+			a_idx = ART_DESTINY;
+			chance = 40;
+			break;
+
+		case MON_GOEMON:
+			a_idx = ART_ZANTETSU;
+			chance = 100;
+			break;
+
+		case MON_HAGEN:
+			a_idx = ART_HAGEN;
+			chance = 66;
+			break;
+
+		case MON_CAINE:
+			a_idx = ART_CAINE;
+			chance = 50;
+			break;
+
+		case MON_BULLGATES:
+			a_idx = ART_WINBLOWS;
+			chance = 66;
+			break;
+
+		case MON_LUNGORTHIN:
+			a_idx = ART_CALRIS;
+			chance = 50;
+			break;
+
+		case MON_JACK_SHADOWS:
+			a_idx = ART_JACK;
+			chance = 15;
+			break;
+
+		case MON_DIO:
+			a_idx = ART_STONEMASK;
+			chance = 20;
+			break;
+
+		case MON_BELD:
+			a_idx = ART_SOULCRUSH;
+			chance = 10;
+			break;
+
+		case MON_PIP:
+			a_idx = ART_EXCALIBUR_J;
+			chance = 50;
+			break;
+
+		case MON_SHUTEN:
+			a_idx = ART_SHUTEN_DOJI;
+			chance = 33;
+			break;
+
+		case MON_GOTHMOG:
+			a_idx = ART_GOTHMOG;
+			chance = 33;
+			break;
+
+		case MON_FUNDIN:
+			a_idx = ART_FUNDIN;
+			chance = 5;
+			break;
+
+		case MON_ROBIN_HOOD:
+			a_idx = ART_ROBIN_HOOD;
+			chance = 5;
+			break;
+
+		case MON_KOGAN:
+			a_idx = ART_NANACHO;
+			chance = 80;
+			break;
+
+		/* #tang 特定モンスター固定ドロップ */		
 		case MON_TANG_CLOAK:
 			a_idx = ART_TANG_CLOAK;
 			chance = 100;
@@ -1313,9 +1496,8 @@ void monster_death(int m_idx, bool drop_item)
 			a_idx = ART_TANG_BOOTS;
 			chance = 100;
 			break;
-		
-		}
 		/* #tang */
+		}
 		
 		/* #tang 
 		for(i = 0; i < 4; i++)

--- a/src/z-config.h
+++ b/src/z-config.h
@@ -573,5 +573,6 @@
 
 
 #ifndef HAVE_CONFIG_H
-#define WORLD_SCORE
+/* #tang スコア送信機能を無効化 */
+/* #define WORLD_SCORE */
 #endif /* HAVE_CONFIG_H */


### PR DESCRIPTION
元あったユニークの固有ドロップを全て復活
ついでにz-conf.hの#define WORLD_SCOREをコメントアウトして、スコア送信関係がオプションからも消えるように
それに伴いpref-opt.prefのX:send_scoreもコメントアウト
